### PR TITLE
Remove section names from header

### DIFF
--- a/sample.tex
+++ b/sample.tex
@@ -7,6 +7,8 @@
 		       % Use 'proposal option if this is a proposal'
 \usepackage{lipsum}
 
+\fancyhead[LO,RE]{} % Remove section names from header
+
 % If you're using the `glossaries` package acronyms (see below)
 %\renewcommand*{\acronymname}{List of Acronyms}
 


### PR DESCRIPTION
This add an option that removes section names from the header by default. This is useful in practice since most section names are long enough that they overflow the header. It also fixes an apparent issue in which the table of contents headers appear twice, since they are both chapter and section titles.
